### PR TITLE
Added '/' to proxy in package.json, replaced .env call for port 8080 in betaApp.js

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -29,7 +29,7 @@
     "test": "jest",
     "eject": "react-scripts eject"
   },
-  "proxy": "http://localhost:8080",
+  "proxy": "http://localhost:8080/",
   "browserslist": {
     "production": [
       ">0.2%",

--- a/server/betaApp.js
+++ b/server/betaApp.js
@@ -20,7 +20,8 @@
 
 (function() {
     "use strict";
-    const PORT_8000 = 8000;
+    const PORT_8000 = "8000";
+    const PORT_8080 = "8080";
 
     const express = require("express");
     const cors = require("cors");
@@ -121,7 +122,7 @@
     }
 
     /** SERVER SETUP **/
-    const port = parseInt(process.env.PORT || PORT_8000, 10);
+    const port = parseInt(PORT_8080 || PORT_8000, 10);
     app.listen(port, () => {
         console.log("Listening on port " + port + "..."); // uncomment for debugging
     });


### PR DESCRIPTION
#88 Using .env variable to call port 8080 break the build to anyone that doesn't have a .env file